### PR TITLE
Unknown param type converter should return the Java delegate if possible

### DIFF
--- a/src/main/resources/vertx/util/utils.rb
+++ b/src/main/resources/vertx/util/utils.rb
@@ -29,6 +29,8 @@ module Vertx
           JsonObject.new(JSON.generate(object))
         elsif object.is_a? Array
           JsonArray.new(JSON.generate(object))
+        elsif object.respond_to?(:j_del)
+          object.j_del
         else
           # Best effort, we let jruby handle the conversion
           object

--- a/src/test/java/io/vertx/test/lang/ruby/EventBusTest.java
+++ b/src/test/java/io/vertx/test/lang/ruby/EventBusTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.test.lang.ruby;
+
+import org.junit.Test;
+
+/**
+ * @author Thomas Segismont
+ */
+public class EventBusTest extends RubyTestBase {
+
+  @Test
+  public void testSendBuffer() throws Exception {
+    runTest();
+  }
+
+  private void runTest() {
+    runTest("event_bus_test", testName.getMethodName());
+  }
+}

--- a/src/test/resources/api_tck_test.rb
+++ b/src/test/resources/api_tck_test.rb
@@ -131,7 +131,7 @@ def testMethodWithHandlerGenericReturn
   handler.call("the-result");
   Assert.equals(result, "the-result")
   handler.call(@obj);
-  Assert.equals(result, @obj)
+  Assert.equals(result, @obj.j_del)
 end
 
 def testMethodWithHandlerVertxGenReturn
@@ -173,7 +173,7 @@ def testMethodWithHandlerAsyncResultGenericReturn
   succeedingHandler.call(nil, "the-result");
   Assert.equals(result, "the-result")
   succeedingHandler.call(nil, @obj);
-  Assert.equals(result, @obj)
+  Assert.equals(result, @obj.j_del)
 end
 
 def testMethodWithHandlerAsyncResultVertxGenReturn

--- a/src/test/resources/event_bus_test.rb
+++ b/src/test/resources/event_bus_test.rb
@@ -1,0 +1,23 @@
+require 'java'
+require 'assert'
+require 'vertx/vertx'
+require 'vertx/buffer'
+
+java_import 'java.util.concurrent.CountDownLatch'
+java_import 'java.util.concurrent.TimeUnit'
+
+def testSendBuffer
+  vertx = Vertx::Vertx.vertx
+  latch = CountDownLatch.new(1)
+
+  event_bus = vertx.event_bus
+  event_bus.consumer('foo') do |msg|
+    Assert.equals('The quick brown fox jumps over the lazy dog', msg.body.to_string)
+    latch.countDown
+  end.completion_handler() do |err, v|
+    Assert.is_nil(err)
+    event_bus.send('foo', Vertx::Buffer.buffer('The quick brown fox jumps over the lazy dog'))
+  end
+
+  Assert.equals(latch.await(2, TimeUnit::MINUTES), true)
+end


### PR DESCRIPTION
Fixes #29

The issue prevents from sending buffers over the event bus.