### PR TITLE
Make the Ruby documentation code examples more idiomatic

### DIFF
--- a/vertx-lang-ruby/src/main/docoverride/vertx-core/ruby/override/configuring-eventbus.adoc
+++ b/vertx-lang-ruby/src/main/docoverride/vertx-core/ruby/override/configuring-eventbus.adoc
@@ -11,11 +11,11 @@ As the event bus acts as a server and client, the configuration is close to {@li
       "path": "keystore.jks",
       "password": "wibble"
     },
-    "trustStoreOptions:" {
+    "trustStoreOptions": {
       "path": "keystore.jks",
       "password": "wibble"
     },
-    clientAuth: "REQUIRED"
+    "clientAuth": "REQUIRED"
   }
 }
 ----

--- a/vertx-lang-ruby/src/main/docoverride/vertx-core/ruby/override/eventbus_headers.adoc
+++ b/vertx-lang-ruby/src/main/docoverride/vertx-core/ruby/override/eventbus_headers.adoc
@@ -10,15 +10,15 @@ options = {
    'some-header' => 'some-value'
  }
 }
-vertx.event_bus().send("news.uk.sport", "Yay! Someone kicked a ball", options)
+$vertx.event_bus.send("news.uk.sport", "Yay! Someone kicked a ball", options)
 ----
 
 On the other side, the consumer can retrieve the message header as follows:
 
 [source, ruby]
 ----
-eb = $vertx.event_bus()
+eb = $vertx.event_bus
 eb.consumer("news.uk.sport") { |message|
- puts message.headers().get("some-header")
+ puts message.headers.get("some-header")
 }
 ----

--- a/vertx-lang-ruby/src/main/docoverride/vertx-core/ruby/override/in-the-beginning.adoc
+++ b/vertx-lang-ruby/src/main/docoverride/vertx-core/ruby/override/in-the-beginning.adoc
@@ -7,14 +7,14 @@ getting a reference to the event bus, setting timers, as well as many other thin
 
 So how do you get an instance?
 
-When you start your application with the CLI, a `vertx` variable will be made available to your code.
+When you start your application with the CLI, a `$vertx` variable will be made available to your code.
 
 [source,ruby]
 ----
-server = vertx.create_http_server() # <1>
-server.request_handler() { |request|
-  request.response().end("Hello world")
-})
+server = $vertx.create_http_server # <1>
+server.request_handler { |request|
+  request.response.end("Hello world")
+}
 server.listen(8080)
 ----
 <1> At runtime, `vertx` variable is available

--- a/vertx-lang-ruby/src/main/docoverride/vertx-core/ruby/override/verticle-configuration.adoc
+++ b/vertx-lang-ruby/src/main/docoverride/vertx-core/ruby/override/verticle-configuration.adoc
@@ -11,7 +11,7 @@ config = {
 options = {
  'config' => config
 }
-vertx.deploy_verticle("MyOrderProcessorVerticle.rb", options)
+$vertx.deploy_verticle("MyOrderProcessorVerticle.rb", options)
 ----
 
 This configuration is then available via the {@link io.vertx.core.Context} object. The configuration is returned as a
@@ -19,14 +19,14 @@ _Hash_ object so you can retrieve data as follows:
 
 [source,ruby]
 ----
-puts $vertx.get_or_create_context().config()["name"]
+puts $vertx.get_or_create_context.config["name"]
 ----
 
 === Accessing environment variables in a Verticle
 
 Environment variables and system properties are accessible from a verticle using the Java API:
 
-[source,javascript]
+[source,ruby]
 ----
 puts Java::JavaLang::System.getProperty("foo")
 puts Java::JavaLang::System.getenv("HOME")

--- a/vertx-lang-ruby/src/main/docoverride/vertx-core/ruby/override/verticles.adoc
+++ b/vertx-lang-ruby/src/main/docoverride/vertx-core/ruby/override/verticles.adoc
@@ -94,12 +94,12 @@ This can be done also possible in Ruby:
 
 [source,ruby]
 ----
-options = { :config => { :GEM_PATH => '/path/to/gems' } }
+options = { config: { GEM_PATH: '/path/to/gems' } }
 $vertx.deploy_verticle('my_verticle.rb', options)
 ----
 
 This option can also be specified for the CLI:
 
 ----
-vertx run my_verticle_rb -conf {\"GEM_PATH\":\"/path/to/gems\"}
+vertx run my_verticle_rb -conf '{"GEM_PATH":"/path/to/gems"}'
 ----

--- a/vertx-lang-ruby/src/test/resources/event_bus_test.rb
+++ b/vertx-lang-ruby/src/test/resources/event_bus_test.rb
@@ -14,7 +14,7 @@ def testSendBuffer
   event_bus.consumer('foo') do |msg|
     Assert.equals('The quick brown fox jumps over the lazy dog', msg.body.to_string)
     latch.countDown
-  end.completion_handler() do |err, v|
+  end.completion_handler do |err, v|
     Assert.is_nil(err)
     event_bus.send('foo', Vertx::Buffer.buffer('The quick brown fox jumps over the lazy dog'))
   end

--- a/vertx-lang-ruby/src/test/resources/examples/bus_echo.rb
+++ b/vertx-lang-ruby/src/test/resources/examples/bus_echo.rb
@@ -1,4 +1,4 @@
-eb = $vertx.event_bus()
+eb = $vertx.event_bus
 
 eb.consumer("ping-address") { |message|
   message.reply "pong"

--- a/vertx-lang-ruby/src/test/resources/examples/simple_http_server.rb
+++ b/vertx-lang-ruby/src/test/resources/examples/simple_http_server.rb
@@ -1,5 +1,5 @@
 require 'vertx/http_server'
-server = $vertx.create_http_server({:port=>8080,:host=>'localhost'})
+server = $vertx.create_http_server(port: 8080, host: 'localhost')
 server.request_handler do |req|
   req.response.end('Hello World')
 end


### PR DESCRIPTION
* See https://github.com/vert-x3/vertx-lang-ruby/issues/41
* `$vertx` is needed and not `vertx`.
* Fix various typos.

I'm not sure where the code `vertx.execute_blocking(lambda { |promise|` on https://vertx.io/docs/vertx-core/ruby/#_writing_verticles comes from. I could not find it in this repo, `vert.x` or `vertx-web-site`.
Is it automatically generated from the Java version in https://github.com/eclipse-vertx/vert.x/blob/59f9e179/src/main/java/examples/CoreExamples.java#L73-L81 ?